### PR TITLE
Fix: Allow ButtplugClient to process incoming message buffer properly preventing disconnection

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -82,6 +82,7 @@ internal class Program {
                 {
                     break;
                 }
+                await Task.Delay(10);
             }
 
             var options = new List<uint>();
@@ -106,6 +107,7 @@ internal class Program {
                     Console.WriteLine($"Device {selectedDevice.Name} selected");
                     break;
                 }
+                await Task.Delay(10);
             }
 
 
@@ -178,6 +180,7 @@ internal class Program {
                         Console.WriteLine($"Problem vibrating: {e}");
                     }
                 }
+                await Task.Delay(10);
             }
 
         }


### PR DESCRIPTION
# Fix: Allow ButtplugClient to process incoming message buffer properly

My last pull request introduced a bug where the `ButtplugClient` did not have enough time to process the incoming message buffer from the server. This caused it to miss answering pings and eventually get disconnected from the server.

By adding a simple `await Task.Delay(10);` in each loop, we give the client enough time to process the buffer and keep the connection open.

Sorry for the inconvenience.